### PR TITLE
feat: containerize plugin behind ovos-tts-server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+test
+**/__pycache__
+*.py[cod]
+.pytest_cache
+*.egg-info
+.venv
+TODO.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,46 @@
+name: docker
+
+on:
+  push:
+    branches: [master, dev]
+    tags: ["*.*.*", "V*", "v*"]
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - pyproject.toml
+      - .github/workflows/docker.yml
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+            type=ref,event=tag
+            type=sha,format=short
+      - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# AhoTTS Basque/Spanish voices served through ovos-tts-server's ElevenLabs-compatible
+# API. A self-contained, offline image: any client that speaks the ovos-tts-server /
+# ElevenLabs API can hit it, and it can be A/B-tested against other ovos-tts-server
+# voices (phoonnx, omnivoice, ...) by pointing at a different port.
+#
+# pyahotts bundles the prebuilt HTS synthesis engine (x86_64 + aarch64 .so) and all
+# voice/dictionary data and emits WAV directly, so no system AhoTTS build, no model
+# download, and no ffmpeg transcode are needed.
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY . /app
+
+# the plugin + pyahotts (self-contained engine + data) + the OVOS TTS server.
+# setuptools<81 keeps ovos-plugin-manager's pkg_resources usage working.
+# ovos-tts-server>=1.13.5a1's alpha floor lets pip resolve the prerelease without --pre.
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir "setuptools<81" "." "ovos-tts-server>=1.13.5a1"
+
+# Default language, overridable with the AHOTTS_LANG build arg ("eu" or "es").
+ARG AHOTTS_LANG=eu
+RUN useradd -m -u 1000 ovos \
+    && mkdir -p /home/ovos/.config/mycroft \
+    && printf '{\n  "tts": {\n    "module": "ovos-tts-plugin-ahotts",\n    "ovos-tts-plugin-ahotts": {\n      "lang": "%s"\n    }\n  }\n}\n' "${AHOTTS_LANG}" \
+        > /home/ovos/.config/mycroft/mycroft.conf \
+    && chown -R 1000:1000 /home/ovos/.config
+USER 1000
+
+EXPOSE 9666
+ENTRYPOINT ["ovos-tts-server", "--engine", "ovos-tts-plugin-ahotts", \
+            "--host", "0.0.0.0", "--port", "9666", "--cache"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,32 @@ OVOS TTS plugin for [AhoTTS](https://github.com/aholab/AhoTTS)
   }
 ```
 
+## Docker
+
+A container that serves this plugin behind [ovos-tts-server](https://github.com/OpenVoiceOS/ovos-tts-server)'s
+ElevenLabs-compatible HTTP API on port `9666` is published to
+`ghcr.io/openvoiceos/ovos-tts-plugin-ahotts`.
+
+The image is fully self-contained and offline: `pyahotts` bundles the synthesis
+engine and all Basque/Spanish voice data, so there is no model download or API key.
+
+```bash
+docker run --rm -p 9666:9666 ghcr.io/openvoiceos/ovos-tts-plugin-ahotts:dev
+```
+
+Or with compose:
+
+```bash
+docker compose up
+```
+
+The served language defaults to Basque (`eu`) and is an `AHOTTS_LANG` build arg
+(`eu` or `es`), so switch it by rebuilding:
+
+```bash
+docker build --build-arg AHOTTS_LANG=es -t ahotts-es .
+```
+
 ## Credits
 
 This plugin was developed by [TigreGotico](https://tigregotico.pt) for OpenVoiceOS under the [ILENIA](https://proyectoilenia.es) project.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  ahotts:
+    image: ghcr.io/openvoiceos/ovos-tts-plugin-ahotts:latest
+    # …or build locally: build: .
+    container_name: ahotts
+    restart: unless-stopped
+    ports:
+      - "9666:9666"
+    # optional: override the served language ("eu" or "es")
+    # environment: {}  # (lang is a build arg; rebuild with --build-arg AHOTTS_LANG=es)
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9666/status')"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 30s


### PR DESCRIPTION
Serves the plugin via `ovos-tts-server`'s ElevenLabs-compatible HTTP API on port 9666, published to `ghcr.io/openvoiceos/ovos-tts-plugin-ahotts`.

## What
- `Dockerfile` — `python:3.11-slim`, installs the plugin + `ovos-tts-server`, runs as non-root uid 1000, entrypoint serves `--engine ovos-tts-plugin-ahotts` on 9666.
- `docker-compose.yml` — one-liner bring-up with a `/status` healthcheck.
- `.github/workflows/docker.yml` — builds on PRs touching the container files; builds + pushes `dev`/`latest`/tag/sha images on branch pushes and tags.
- `.dockerignore` and a README "Docker" section.

## Notes
The image is fully self-contained and offline: `pyahotts` bundles the prebuilt HTS engine (x86_64 + aarch64) and all Basque/Spanish voice data and emits WAV, so there is no model download, no API key, and no `ffmpeg`/apt dependency. Default served language is Basque (`eu`); overridable via the `AHOTTS_LANG` build arg (`eu`/`es`).