### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # OVOS TTS Plugin AhoTTS
 
-## Description
-
-OVOS TTS plugin for [AhoTTS](https://github.com/aholab/AhoTTS)
+An OVOS text-to-speech plugin for [AhoTTS](https://github.com/aholab/AhoTTS). It generates
+speech in Basque (`eu`) and Spanish (`es`).
 
 ## Install
 
-`pip install ovos-tts-plugin-ahotts`
-
+```bash
+pip install ovos-tts-plugin-ahotts
+```
 
 ## Configuration
 
@@ -22,12 +22,15 @@ OVOS TTS plugin for [AhoTTS](https://github.com/aholab/AhoTTS)
 
 ## Docker
 
-A container that serves this plugin behind [ovos-tts-server](https://github.com/OpenVoiceOS/ovos-tts-server)'s
+A container that serves this plugin behind [OpenVoiceOS/ovos-tts-server](https://github.com/OpenVoiceOS/ovos-tts-server)'s
 ElevenLabs-compatible HTTP API on port `9666` is published to
 `ghcr.io/openvoiceos/ovos-tts-plugin-ahotts`.
 
-The image is fully self-contained and offline: `pyahotts` bundles the synthesis
-engine and all Basque/Spanish voice data, so there is no model download or API key.
+The image is fully self-contained and offline. `pyahotts` bundles the synthesis engine
+and all Basque and Spanish voice data, so the container needs no model download and no
+API key.
+
+Run the container:
 
 ```bash
 docker run --rm -p 9666:9666 ghcr.io/openvoiceos/ovos-tts-plugin-ahotts:dev
@@ -39,12 +42,18 @@ Or with compose:
 docker compose up
 ```
 
-The served language defaults to Basque (`eu`) and is an `AHOTTS_LANG` build arg
-(`eu` or `es`), so switch it by rebuilding:
+The served language defaults to Basque (`eu`) and is set by the `AHOTTS_LANG` build arg
+(`eu` or `es`). To switch it, rebuild the image:
 
 ```bash
 docker build --build-arg AHOTTS_LANG=es -t ahotts-es .
 ```
+
+## Related projects
+
+- [OpenVoiceOS/ovos-tts-server](https://github.com/OpenVoiceOS/ovos-tts-server): the HTTP server this plugin's Docker image runs behind.
+- [OpenVoiceOS/ovos-plugin-manager](https://github.com/OpenVoiceOS/ovos-plugin-manager): loads and manages this plugin at runtime.
+- [aholab/AhoTTS](https://github.com/aholab/AhoTTS): the upstream synthesis engine this plugin wraps.
 
 ## Credits
 
@@ -53,3 +62,7 @@ This plugin was developed by [TigreGotico](https://tigregotico.pt) for OpenVoice
 <img src="img.png" width="128"/>
 
 > This plugin was funded by the Ministerio para la Transformación Digital y de la Función Pública and Plan de Recuperación, Transformación y Resiliencia - Funded by EU – NextGenerationEU within the framework of the project [ILENIA](https://proyectoilenia.es) with reference 2022/TL22/00215337
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
Rewrites the README for clarity: tightens the wording, states the supported languages up front, and adds a Related projects section linking ovos-tts-server, ovos-plugin-manager, and the upstream AhoTTS engine. No facts, code blocks, or the funding note were changed.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented supported Basque and Spanish languages.
  * Clarified Docker image offline and self-contained behavior.
  * Added instructions for selecting the language during builds.
  * Improved installation formatting and added related-project and license information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->